### PR TITLE
Add n_records option to db_bulk_insert

### DIFF
--- a/lib/em-pg-client-helper.rb
+++ b/lib/em-pg-client-helper.rb
@@ -231,12 +231,12 @@ module PG::EM::Client::Helper
 	#
 	# @since 2.0.0
 	#
-	def db_bulk_insert(db, tbl, columns, rows, &blk)
+	def db_bulk_insert(db, tbl, columns, rows, opts={}, &blk)
 		EM::Completion.new.tap do |df|
 			df.callback(&blk) if blk
 
 			db_transaction(db) do |txn|
-				txn.bulk_insert(tbl, columns, rows) do |count|
+				txn.bulk_insert(tbl, columns, rows, opts) do |count|
 					txn.commit do
 						df.succeed(count)
 					end

--- a/lib/em-pg-client-helper/transaction.rb
+++ b/lib/em-pg-client-helper/transaction.rb
@@ -238,7 +238,7 @@ class PG::EM::Client::Helper::Transaction
 	# @since 2.0.0
 	#
 	def bulk_insert(tbl, columns, rows, opts={}, &blk)
-		n_records = opts.fetch(:n_records, 2)
+		n_records = opts.fetch(:n_records, 100)
 		if rows.length > n_records
 			bulk_insert(tbl, columns, rows[0...n_records]) do |count1|
 				bulk_insert(tbl, columns, rows[n_records..-1]) do |count2|

--- a/lib/em-pg-client-helper/transaction.rb
+++ b/lib/em-pg-client-helper/transaction.rb
@@ -237,10 +237,11 @@ class PG::EM::Client::Helper::Transaction
 	#
 	# @since 2.0.0
 	#
-	def bulk_insert(tbl, columns, rows, &blk)
-		if rows.length > 1000
-			bulk_insert(tbl, columns, rows[0..999]) do |count1|
-				bulk_insert(tbl, columns, rows[1000..-1]) do |count2|
+	def bulk_insert(tbl, columns, rows, opts={}, &blk)
+		n_records = opts.fetch(:n_records, 2)
+		if rows.length > n_records
+			bulk_insert(tbl, columns, rows[0...n_records]) do |count1|
+				bulk_insert(tbl, columns, rows[n_records..-1]) do |count2|
 					blk.call(count1 + count2)
 				end
 			end


### PR DESCRIPTION
This specifies the number of records inserted per transaction when bulk
insterting.
